### PR TITLE
Add an explicit list of users allowed to register

### DIFF
--- a/roost_ng/settings/roost.py
+++ b/roost_ng/settings/roost.py
@@ -3,5 +3,6 @@ from . import config
 cfg = config.get_config_for_module(__name__)
 
 ROOST_ALLOW_USER_CREATION = cfg.get('allow_user_creation', True)
+ROOST_USER_CREATION_ALLOWLIST= set(cfg.get('user_allowlist', []))
 ROOST_USER_CREATION_BLACKLIST = cfg.get('user_blacklist', [])
 ROOST_MESSAGES_MAX_LIMIT = cfg.get('message_max_limit', 128)


### PR DESCRIPTION
This allows somebody running a private server to populate /etc/roost-ng/config.yml with the Kerberos principals (including realm)
that can register, rather than temporarily turning on registrations and then turning them off again when the right people have registered.