### PR TITLE
Add punt hook to drop admin-chosen messages

### DIFF
--- a/roost_backend/subscribers.py
+++ b/roost_backend/subscribers.py
@@ -18,6 +18,7 @@ import django.apps
 from django.core.exceptions import AppRegistryNotReady
 from django.db import IntegrityError, transaction
 from django.db.models import Q
+from django.conf import settings
 from djangorestframework_camel_case.util import underscoreize
 import setproctitle
 import zephyr
@@ -234,6 +235,10 @@ class _ZephyrProcessMixin(_ChannelLayerMixin):
                     continue
                 if notice.opcode.lower() == b'ping':
                     # Ignoring pings
+                    continue
+                if settings.ROOST_CHECK_PUNT(notice):
+                    _LOGGER.getChild('punt').info("[%s] zephyr handler punting znotice %s, %s",
+                                                  self.log_prefix, notice, notice.__dict__)
                     continue
                 # This appears to be an incoming message.
                 msg = django.apps.apps.get_model('roost_backend', 'Message').from_notice(notice)

--- a/roost_ng/settings/roost.py
+++ b/roost_ng/settings/roost.py
@@ -13,3 +13,13 @@ ROOST_USER_CREATION_DENYLIST = cfg.get('user_denylist', [])
 # Making this operator tweakable so we can experiment.
 # JS roost had a 100 message limit. Snipe asked for 128 messages.
 ROOST_MESSAGES_MAX_LIMIT = cfg.get('message_max_limit', 128)
+
+def ROOST_CHECK_PUNT(znotice):
+    """Hook to optionally drop certain messages before adding to DB
+
+    Useful if there's a class with some useful messages, but also a high
+    rate of messages that nobody needs to see that unnecessarily load the
+    server.
+
+    Returns a bool indicating whether or not to punt a message."""
+    return False


### PR DESCRIPTION
Useful if there's a class with some useful messages, but also a high rate of messages that nobody needs to see that unnecessarily load the server.